### PR TITLE
Add Foundation

### DIFF
--- a/src/marketplaces/foundation/FoundationConfig.sol
+++ b/src/marketplaces/foundation/FoundationConfig.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.7;
+
+import { BaseMarketConfig } from "../../BaseMarketConfig.sol";
+import { IFoundation } from "./interfaces/IFoundation.sol";
+import { TestCallParameters, TestOrderContext, TestOrderPayload, TestItem721, TestItem1155, TestItem20 } from "../../Types.sol";
+
+contract FoundationConfig is BaseMarketConfig {
+    function name() external pure override returns (string memory) {
+        return "Foundation";
+    }
+
+    function market() public pure override returns (address) {
+        return address(foundation);
+    }
+
+    IFoundation internal constant foundation =
+        IFoundation(0xcDA72070E455bb31C7690a170224Ce43623d0B6f);
+
+    function beforeAllPrepareMarketplace(address, address) external override {
+        // ERC-20 n/a but currently required by the test suite
+        buyerNftApprovalTarget = sellerNftApprovalTarget = buyerErc20ApprovalTarget = sellerErc20ApprovalTarget = address(
+            foundation
+        );
+    }
+
+    function getPayload_BuyOfferedERC721WithEther(
+        TestOrderContext calldata context,
+        TestItem721 calldata nft,
+        uint256 ethAmount
+    ) external view override returns (TestOrderPayload memory execution) {
+        if(!context.listOnChain) {
+            _notImplemented();
+        }
+
+        execution.submitOrder = TestCallParameters(
+            address(foundation),
+            0,
+            abi.encodeWithSelector(IFoundation.setBuyPrice.selector, nft.token, nft.identifier, ethAmount)
+        );
+        execution.executeOrder = TestCallParameters(
+            address(foundation),
+            ethAmount,
+            abi.encodeWithSelector(
+                IFoundation.buyV2.selector,
+                nft.token, nft.identifier, ethAmount, address(0)
+            )
+        );
+    }
+    
+    function getPayload_BuyOfferedERC721WithEtherOneFeeRecipient(
+        TestOrderContext calldata context,
+        TestItem721 memory nft,
+        uint256 priceEthAmount,
+        address feeRecipient,
+        uint256 feeEthAmount
+    ) external view override returns (TestOrderPayload memory execution) {
+        if(!context.listOnChain) {
+            _notImplemented();
+        }
+
+        execution.submitOrder = TestCallParameters(
+            address(foundation),
+            0,
+            abi.encodeWithSelector(IFoundation.setBuyPrice.selector, nft.token, nft.identifier, priceEthAmount)
+        );
+        execution.executeOrder = TestCallParameters(
+            address(foundation),
+            priceEthAmount,
+            abi.encodeWithSelector(
+                IFoundation.buyV2.selector,
+                nft.token, nft.identifier, priceEthAmount, feeRecipient
+            )
+        );
+    }
+
+    function getPayload_BuyOfferedERC721WithEtherTwoFeeRecipient(
+        TestOrderContext calldata context,
+        TestItem721 memory nft,
+        uint256 priceEthAmount,
+        address feeRecipient1,
+        uint256 feeEthAmount1,
+        address feeRecipient2,
+        uint256 feeEthAmount2
+    ) external view override returns (TestOrderPayload memory execution) {
+        if(!context.listOnChain) {
+            _notImplemented();
+        }
+
+        // TODO: pending sell referrer support
+        _notImplemented();
+    }
+}

--- a/src/marketplaces/foundation/FoundationConfig.sol
+++ b/src/marketplaces/foundation/FoundationConfig.sol
@@ -29,25 +29,33 @@ contract FoundationConfig is BaseMarketConfig {
         TestItem721 calldata nft,
         uint256 ethAmount
     ) external view override returns (TestOrderPayload memory execution) {
-        if(!context.listOnChain) {
+        if (!context.listOnChain) {
             _notImplemented();
         }
 
         execution.submitOrder = TestCallParameters(
             address(foundation),
             0,
-            abi.encodeWithSelector(IFoundation.setBuyPrice.selector, nft.token, nft.identifier, ethAmount)
+            abi.encodeWithSelector(
+                IFoundation.setBuyPrice.selector,
+                nft.token,
+                nft.identifier,
+                ethAmount
+            )
         );
         execution.executeOrder = TestCallParameters(
             address(foundation),
             ethAmount,
             abi.encodeWithSelector(
                 IFoundation.buyV2.selector,
-                nft.token, nft.identifier, ethAmount, address(0)
+                nft.token,
+                nft.identifier,
+                ethAmount,
+                address(0)
             )
         );
     }
-    
+
     function getPayload_BuyOfferedERC721WithEtherOneFeeRecipient(
         TestOrderContext calldata context,
         TestItem721 memory nft,
@@ -55,21 +63,29 @@ contract FoundationConfig is BaseMarketConfig {
         address feeRecipient,
         uint256 feeEthAmount
     ) external view override returns (TestOrderPayload memory execution) {
-        if(!context.listOnChain) {
+        if (!context.listOnChain) {
             _notImplemented();
         }
 
         execution.submitOrder = TestCallParameters(
             address(foundation),
             0,
-            abi.encodeWithSelector(IFoundation.setBuyPrice.selector, nft.token, nft.identifier, priceEthAmount)
+            abi.encodeWithSelector(
+                IFoundation.setBuyPrice.selector,
+                nft.token,
+                nft.identifier,
+                priceEthAmount
+            )
         );
         execution.executeOrder = TestCallParameters(
             address(foundation),
             priceEthAmount,
             abi.encodeWithSelector(
                 IFoundation.buyV2.selector,
-                nft.token, nft.identifier, priceEthAmount, feeRecipient
+                nft.token,
+                nft.identifier,
+                priceEthAmount,
+                feeRecipient
             )
         );
     }
@@ -83,7 +99,7 @@ contract FoundationConfig is BaseMarketConfig {
         address feeRecipient2,
         uint256 feeEthAmount2
     ) external view override returns (TestOrderPayload memory execution) {
-        if(!context.listOnChain) {
+        if (!context.listOnChain) {
             _notImplemented();
         }
 

--- a/src/marketplaces/foundation/interfaces/IFoundation.sol
+++ b/src/marketplaces/foundation/interfaces/IFoundation.sol
@@ -3,6 +3,16 @@
 pragma solidity ^0.8.0;
 
 interface IFoundation {
-	function setBuyPrice(address nftContract, uint256 tokenId, uint256 price) external;
-	function buyV2(address nftContract, uint256 tokenId, uint256 maxPrice, address payable buyReferrer) external payable;
+    function setBuyPrice(
+        address nftContract,
+        uint256 tokenId,
+        uint256 price
+    ) external;
+
+    function buyV2(
+        address nftContract,
+        uint256 tokenId,
+        uint256 maxPrice,
+        address payable buyReferrer
+    ) external payable;
 }

--- a/src/marketplaces/foundation/interfaces/IFoundation.sol
+++ b/src/marketplaces/foundation/interfaces/IFoundation.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+pragma solidity ^0.8.0;
+
+interface IFoundation {
+	function setBuyPrice(address nftContract, uint256 tokenId, uint256 price) external;
+	function buyV2(address nftContract, uint256 tokenId, uint256 maxPrice, address payable buyReferrer) external payable;
+}

--- a/test/GenericMarketplaceTest.t.sol
+++ b/test/GenericMarketplaceTest.t.sol
@@ -736,7 +736,8 @@ contract GenericMarketplaceTest is BaseOrderTest {
                 payload.submitOrder
             );
 
-            assertEq(test721_1.ownerOf(1), alice);
+            // Allow the market to escrow after listing
+            assert(test721_1.ownerOf(1) == alice || test721_1.ownerOf(1) == config.market());
             assertEq(feeReciever1.balance, 0);
             assertEq(feeReciever2.balance, 0);
 

--- a/test/GenericMarketplaceTest.t.sol
+++ b/test/GenericMarketplaceTest.t.sol
@@ -16,7 +16,7 @@ import "./utils/BaseOrderTest.sol";
 contract GenericMarketplaceTest is BaseOrderTest {
     BaseMarketConfig seaportConfig;
     BaseMarketConfig wyvernConfig;
-    BaseMarketConfig foundationConfig;    
+    BaseMarketConfig foundationConfig;
 
     constructor() {
         seaportConfig = BaseMarketConfig(new SeaportConfig());
@@ -103,7 +103,10 @@ contract GenericMarketplaceTest is BaseOrderTest {
             );
 
             // Allow the market to escrow after listing
-            assert(test721_1.ownerOf(1) == alice || test721_1.ownerOf(1) == config.market());
+            assert(
+                test721_1.ownerOf(1) == alice ||
+                    test721_1.ownerOf(1) == config.market()
+            );
 
             _benchmarkCallWithParams(
                 config.name(),
@@ -663,7 +666,10 @@ contract GenericMarketplaceTest is BaseOrderTest {
             );
 
             // Allow the market to escrow after listing
-            assert(test721_1.ownerOf(1) == alice || test721_1.ownerOf(1) == config.market());
+            assert(
+                test721_1.ownerOf(1) == alice ||
+                    test721_1.ownerOf(1) == config.market()
+            );
             assertEq(feeReciever1.balance, 0);
 
             _benchmarkCallWithParams(
@@ -737,7 +743,10 @@ contract GenericMarketplaceTest is BaseOrderTest {
             );
 
             // Allow the market to escrow after listing
-            assert(test721_1.ownerOf(1) == alice || test721_1.ownerOf(1) == config.market());
+            assert(
+                test721_1.ownerOf(1) == alice ||
+                    test721_1.ownerOf(1) == config.market()
+            );
             assertEq(feeReciever1.balance, 0);
             assertEq(feeReciever2.balance, 0);
 


### PR DESCRIPTION
We only support 721 -> Ether sales, when listed on-chain.

I needed to modify the tests to allow the market contract to escrow after listing.

For the fee recipients, we currently hard code the amount received to 1%. This will change in the future, but for now I updated the test so that the numbers align to the expected 1%.

Let us know if there's anything we might have missed.

Thanks for putting this together! Looking forward to having all the marketplaces included in this report.

----

The output (excluding unsupported calls)
```
  [Foundation] (ERC721 -> ETH List-On-Chain) List (direct) -- gas: 74027
  [Foundation] (ERC721 -> ETH List-On-Chain) List -- gas: 93139
  [Foundation] (ERC721 -> ETH List-On-Chain) Fulfill (direct) -- gas: 92295
  [Foundation] (ERC721 -> ETH List-On-Chain) Fulfill -- gas: 111535
  [Foundation] (ERC721 -> ETH One-Fee-Recipient List-On-Chain) List (direct) -- gas: 50227
  [Foundation] (ERC721 -> ETH One-Fee-Recipient List-On-Chain) List -- gas: 69351
  [Foundation] (ERC721 -> ETH One-Fee-Recipient List-On-Chain) Fulfill (direct) -- gas: 102845
  [Foundation] (ERC721 -> ETH One-Fee-Recipient List-On-Chain) Fulfill -- gas: 122337


  [Seaport] (ERC721 -> ETH List-On-Chain) List (direct) -- gas: 36456
  [Seaport] (ERC721 -> ETH List-On-Chain) List -- gas: 60920
  [Seaport] (ERC721 -> ETH List-On-Chain) Fulfill (direct) -- gas: 55524
  [Seaport] (ERC721 -> ETH List-On-Chain) Fulfill -- gas: 77300
  [Seaport] (ERC721 -> ETH One-Fee-Recipient List-On-Chain) List (direct) -- gas: 30665
  [Seaport] (ERC721 -> ETH One-Fee-Recipient List-On-Chain) List -- gas: 56185
  [Seaport] (ERC721 -> ETH One-Fee-Recipient List-On-Chain) Fulfill (direct) -- gas: 85277
  [Seaport] (ERC721 -> ETH One-Fee-Recipient List-On-Chain) Fulfill -- gas: 107597
```