### PR TITLE
Add sudoswap marketplace tests

### DIFF
--- a/src/BaseMarketConfig.sol
+++ b/src/BaseMarketConfig.sol
@@ -9,7 +9,7 @@ abstract contract BaseMarketConfig {
      */
     function name() external pure virtual returns (string memory);
 
-    function market() public pure virtual returns (address);
+    function market() public view virtual returns (address);
 
     /**
      * @dev Address that should be approved for nft tokens
@@ -75,7 +75,7 @@ abstract contract BaseMarketConfig {
         TestOrderContext calldata context,
         TestItem721 calldata nft,
         uint256 ethAmount
-    ) external view virtual returns (TestOrderPayload memory execution) {
+    ) external virtual returns (TestOrderPayload memory execution) {
         _notImplemented();
     }
 
@@ -109,7 +109,7 @@ abstract contract BaseMarketConfig {
         TestOrderContext calldata context,
         TestItem721 calldata nft,
         TestItem20 calldata erc20
-    ) external view virtual returns (TestOrderPayload memory execution) {
+    ) external virtual returns (TestOrderPayload memory execution) {
         _notImplemented();
     }
 
@@ -143,7 +143,7 @@ abstract contract BaseMarketConfig {
         TestOrderContext calldata context,
         TestItem20 calldata erc20,
         TestItem721 calldata nft
-    ) external view virtual returns (TestOrderPayload memory execution) {
+    ) external virtual returns (TestOrderPayload memory execution) {
         _notImplemented();
     }
 
@@ -257,7 +257,7 @@ abstract contract BaseMarketConfig {
         TestOrderContext calldata context,
         TestItem721[] calldata nfts,
         uint256 ethAmount
-    ) external view virtual returns (TestOrderPayload memory execution) {
+    ) external virtual returns (TestOrderPayload memory execution) {
         _notImplemented();
     }
 

--- a/src/BaseMarketConfig.sol
+++ b/src/BaseMarketConfig.sol
@@ -276,6 +276,24 @@ abstract contract BaseMarketConfig {
         _notImplemented();
     }
 
+    /**
+     * @dev Get call parameters to execute an order "sweeping the floor" buy filling 10 distinct
+     *   ERC-721->ETH orders at once. Same seller on each order. If the market does not support the
+     *   order type, must revert with NotImplemented.
+     * @param contexts Array of contexts for each order
+     * @param erc20Address The erc20 address to use across orders
+     * @param nfts Array of NFTs for each order
+     * @param erc20Amounts Array of Erc20 amounts to be received for the NFTs in each order
+     */
+    function getPayload_BuyOfferedManyERC721WithErc20DistinctOrders(
+        TestOrderContext[] calldata contexts,
+        address erc20Address,
+        TestItem721[] calldata nfts,
+        uint256[] calldata erc20Amounts
+    ) external view virtual returns (TestOrderPayload memory execution) {
+        _notImplemented();
+    }
+
     /*//////////////////////////////////////////////////////////////
                           Helpers
     //////////////////////////////////////////////////////////////*/

--- a/src/BaseMarketConfig.sol
+++ b/src/BaseMarketConfig.sol
@@ -42,7 +42,8 @@ abstract contract BaseMarketConfig {
     function beforeAllPrepareMarketplaceCall(
         address seller,
         address buyer,
-        address[] calldata erc20Tokens
+        address[] calldata erc20Tokens,
+        address[] calldata erc721Tokens
     ) external virtual returns (SetupCall[] memory) {
         SetupCall[] memory empty = new SetupCall[](0);
         return empty;

--- a/src/marketplaces/X2Y2/X2Y2Config.sol
+++ b/src/marketplaces/X2Y2/X2Y2Config.sol
@@ -34,6 +34,7 @@ contract X2Y2Config is BaseMarketConfig, X2Y2TypeHashes {
     function beforeAllPrepareMarketplaceCall(
         address seller,
         address,
+        address[] calldata,
         address[] calldata
     ) external override returns (SetupCall[] memory) {
         SetupCall[] memory setupCalls = new SetupCall[](1);
@@ -42,7 +43,7 @@ contract X2Y2Config is BaseMarketConfig, X2Y2TypeHashes {
         address[] memory addSigners = new address[](1);
         addSigners[0] = seller;
 
-        // Set seller as a signer for D2Y2
+        // Set seller as a signer for X2Y2
         setupCalls[0] = SetupCall(
             X2Y2Owner,
             address(X2Y2),

--- a/src/marketplaces/X2Y2/X2Y2Config.sol
+++ b/src/marketplaces/X2Y2/X2Y2Config.sol
@@ -403,4 +403,21 @@ contract X2Y2Config is BaseMarketConfig, X2Y2TypeHashes {
             payload
         );
     }
+
+    function getPayload_BuyOfferedManyERC721WithErc20DistinctOrders(
+        TestOrderContext[] calldata contexts,
+        address erc20Address,
+        TestItem721[] calldata nfts,
+        uint256[] calldata erc20Amounts
+    ) external view override returns (TestOrderPayload memory execution) {
+        (bytes memory payload, ) = encodeFillOrderDistinctOrders(
+            contexts,
+            nfts,
+            erc20Amounts,
+            erc20Address,
+            Market.INTENT_SELL
+        );
+
+        execution.executeOrder = TestCallParameters(address(X2Y2), 0, payload);
+    }
 }

--- a/src/marketplaces/looksRare/LooksRareConfig.sol
+++ b/src/marketplaces/looksRare/LooksRareConfig.sol
@@ -101,7 +101,8 @@ contract LooksRareConfig is BaseMarketConfig, LooksRareTypeHashes {
     function beforeAllPrepareMarketplaceCall(
         address,
         address,
-        address[] calldata erc20Tokens
+        address[] calldata erc20Tokens,
+        address[] calldata
     ) external pure override returns (SetupCall[] memory) {
         SetupCall[] memory setupCalls = new SetupCall[](erc20Tokens.length + 1);
         for (uint256 i = 0; i < erc20Tokens.length; i++) {

--- a/src/marketplaces/sudoswap/SudoswapConfig.sol
+++ b/src/marketplaces/sudoswap/SudoswapConfig.sol
@@ -12,7 +12,7 @@ contract SudoswapConfig is BaseMarketConfig {
     IPairFactory constant PAIR_FACTORY =
         IPairFactory(0xb16c1342E617A5B6E4b631EB114483FDB289c0A4);
     IRouter constant ROUTER =
-        IRouter(0x2B2e8cDA09bBA9660dCA5cB6233787738Ad68329);
+        IRouter(0x77f4DF87F1908Bd48Ec71bF0579c446B76a416C2);
     address constant LINEAR_CURVE = 0x5B6aC51d9B1CeDE0068a1B26533CAce807f883Ee;
 
     uint128 constant DELTA = 1;
@@ -121,24 +121,19 @@ contract SudoswapConfig is BaseMarketConfig {
         });
 
         // construct executeOrder payload
-        // fulfiller calls router
+        // fulfiller calls pair directly to swap
         uint256[] memory nftIds = new uint256[](1);
         nftIds[0] = nft.identifier;
-        IRouter.PairSwapSpecific[]
-            memory swapList = new IRouter.PairSwapSpecific[](1);
-        swapList[0] = IRouter.PairSwapSpecific({
-            pair: address(ethNftPool),
-            nftIds: nftIds
-        });
         execution.executeOrder = TestCallParameters({
-            target: address(ROUTER),
+            target: address(ethNftPool),
             value: ethAmount,
             data: abi.encodeWithSelector(
-                IRouter.swapETHForSpecificNFTs.selector,
-                swapList,
+                IPair.swapTokenForSpecificNFTs.selector,
+                nftIds,
+                type(uint256).max,
                 context.fulfiller,
-                context.fulfiller,
-                type(uint256).max
+                false,
+                address(0)
             )
         });
     }

--- a/src/marketplaces/sudoswap/SudoswapConfig.sol
+++ b/src/marketplaces/sudoswap/SudoswapConfig.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.8.0;
+
+import { BaseMarketConfig } from "../../BaseMarketConfig.sol";
+import { SetupCall, TestCallParameters, TestOrderContext, TestOrderPayload, TestItem721, TestItem1155, TestItem20 } from "../../Types.sol";
+import {IRouter} from "./interfaces/IRouter.sol";
+import {IPairFactory} from "./interfaces/IPairFactory.sol";
+
+contract SudoswapConfig is BaseMarketConfig {
+
+    IPairFactory constant PAIR_FACTORY = 0xb16c1342E617A5B6E4b631EB114483FDB289c0A4;
+    IRouter constant ROUTER = IRouter(0x2B2e8cDA09bBA9660dCA5cB6233787738Ad68329);
+
+    function name() external pure override returns (string memory) {
+        return "sudoswap";
+    }
+
+    function market() public pure override returns (address) {
+        return address(PAIR_FACTORY);
+    }
+
+
+}

--- a/src/marketplaces/sudoswap/SudoswapConfig.sol
+++ b/src/marketplaces/sudoswap/SudoswapConfig.sol
@@ -1,22 +1,246 @@
 pragma solidity ^0.8.0;
 
+import "solmate/tokens/ERC20.sol";
+
 import { BaseMarketConfig } from "../../BaseMarketConfig.sol";
 import { SetupCall, TestCallParameters, TestOrderContext, TestOrderPayload, TestItem721, TestItem1155, TestItem20 } from "../../Types.sol";
-import {IRouter} from "./interfaces/IRouter.sol";
-import {IPairFactory} from "./interfaces/IPairFactory.sol";
+import { IPair } from "./interfaces/IPair.sol";
+import { IRouter } from "./interfaces/IRouter.sol";
+import { IPairFactory } from "./interfaces/IPairFactory.sol";
 
 contract SudoswapConfig is BaseMarketConfig {
+    IPairFactory constant PAIR_FACTORY =
+        IPairFactory(0xb16c1342E617A5B6E4b631EB114483FDB289c0A4);
+    IRouter constant ROUTER =
+        IRouter(0x2B2e8cDA09bBA9660dCA5cB6233787738Ad68329);
+    address constant LINEAR_CURVE = 0x5B6aC51d9B1CeDE0068a1B26533CAce807f883Ee;
 
-    IPairFactory constant PAIR_FACTORY = 0xb16c1342E617A5B6E4b631EB114483FDB289c0A4;
-    IRouter constant ROUTER = IRouter(0x2B2e8cDA09bBA9660dCA5cB6233787738Ad68329);
+    uint128 constant DELTA = 1;
+    uint128 constant NFT_PRICE = 100; // the price at which NFTs are being bought/sold
+    uint128 constant TOKEN_POOL_SPOT_PRICE = NFT_PRICE;
+    uint128 constant NFT_POOL_SPOT_PRICE = TOKEN_POOL_SPOT_PRICE - DELTA;
+
+    IPair erc20TokenPool; // owned by seller, who sells ERC20 to buy ERC721
+    IPair ethNftPool; // owned by seller, who sells ERC721 to buy ETH
+    IPair erc20NftPool; // owned by seller, who sells ERC721 to buy ERC20
+    address erc20Address;
+    address erc721Address;
+    address currentMarket; // the current address that stores the listed ERC721
 
     function name() external pure override returns (string memory) {
         return "sudoswap";
     }
 
-    function market() public pure override returns (address) {
-        return address(PAIR_FACTORY);
+    function market() public view override returns (address) {
+        return currentMarket;
     }
 
+    function beforeAllPrepareMarketplace(address, address) external override {
+        buyerNftApprovalTarget = sellerNftApprovalTarget = buyerErc20ApprovalTarget = sellerErc20ApprovalTarget = address(
+            ROUTER
+        );
+    }
 
+    function beforeAllPrepareMarketplaceCall(
+        address seller,
+        address buyer,
+        address[] calldata erc20Addresses,
+        address[] calldata erc721Addresses
+    ) external override returns (SetupCall[] memory) {
+        // record tokens
+        erc20Address = erc20Addresses[0];
+        erc721Address = erc721Addresses[0];
+
+        // deploy pools
+        uint256[] memory empty;
+
+        erc20TokenPool = PAIR_FACTORY.createPairERC20(
+            IPairFactory.CreateERC20PairParams({
+                token: erc20Addresses[0],
+                nft: erc721Addresses[0],
+                bondingCurve: LINEAR_CURVE,
+                assetRecipient: payable(seller),
+                poolType: IPairFactory.PoolType.TOKEN,
+                delta: DELTA,
+                fee: 0,
+                spotPrice: TOKEN_POOL_SPOT_PRICE,
+                initialNFTIDs: empty,
+                initialTokenBalance: 0
+            })
+        );
+
+        ethNftPool = PAIR_FACTORY.createPairETH(
+            erc721Addresses[0],
+            LINEAR_CURVE,
+            payable(seller),
+            IPairFactory.PoolType.NFT,
+            DELTA,
+            0,
+            NFT_POOL_SPOT_PRICE,
+            empty
+        );
+
+        erc20NftPool = PAIR_FACTORY.createPairERC20(
+            IPairFactory.CreateERC20PairParams({
+                token: erc20Addresses[0],
+                nft: erc721Addresses[0],
+                bondingCurve: LINEAR_CURVE,
+                assetRecipient: payable(seller),
+                poolType: IPairFactory.PoolType.NFT,
+                delta: DELTA,
+                fee: 0,
+                spotPrice: NFT_POOL_SPOT_PRICE,
+                initialNFTIDs: empty,
+                initialTokenBalance: 0
+            })
+        );
+    }
+
+    function getPayload_BuyOfferedERC721WithEther(
+        TestOrderContext calldata context,
+        TestItem721 memory nft,
+        uint256 ethAmount
+    ) external override returns (TestOrderPayload memory execution) {
+        if (!context.listOnChain || nft.token != erc721Address)
+            _notImplemented();
+
+        // update market address so tests know where the ERC721 will be escrowed
+        currentMarket = address(ethNftPool);
+
+        // construct submitOrder payload
+        // offerer transfers ERC721 to ethNftPool
+        execution.submitOrder = TestCallParameters({
+            target: nft.token,
+            value: 0,
+            data: abi.encodeWithSignature(
+                "safeTransferFrom(address,address,uint256)",
+                context.offerer,
+                address(ethNftPool),
+                nft.identifier
+            )
+        });
+
+        // construct executeOrder payload
+        // fulfiller calls router
+        uint256[] memory nftIds = new uint256[](1);
+        nftIds[0] = nft.identifier;
+        IRouter.PairSwapSpecific[]
+            memory swapList = new IRouter.PairSwapSpecific[](1);
+        swapList[0] = IRouter.PairSwapSpecific({
+            pair: address(ethNftPool),
+            nftIds: nftIds
+        });
+        execution.executeOrder = TestCallParameters({
+            target: address(ROUTER),
+            value: ethAmount,
+            data: abi.encodeWithSelector(
+                IRouter.swapETHForSpecificNFTs.selector,
+                swapList,
+                context.fulfiller,
+                context.fulfiller,
+                type(uint256).max
+            )
+        });
+    }
+
+    function getPayload_BuyOfferedERC721WithERC20(
+        TestOrderContext calldata context,
+        TestItem721 calldata nft,
+        TestItem20 calldata erc20
+    ) external override returns (TestOrderPayload memory execution) {
+        if (
+            !context.listOnChain ||
+            nft.token != erc721Address ||
+            erc20.token != erc20Address ||
+            erc20.amount != NFT_PRICE
+        ) _notImplemented();
+
+        // update market address so tests know where the ERC721 will be escrowed
+        currentMarket = address(erc20NftPool);
+
+        // construct submitOrder payload
+        // offerer transfers ERC721 to erc20NftPool
+        execution.submitOrder = TestCallParameters({
+            target: nft.token,
+            value: 0,
+            data: abi.encodeWithSignature(
+                "safeTransferFrom(address,address,uint256)",
+                context.offerer,
+                address(erc20NftPool),
+                nft.identifier
+            )
+        });
+
+        // construct executeOrder payload
+        // fulfiller calls router
+        uint256[] memory nftIds = new uint256[](1);
+        nftIds[0] = nft.identifier;
+        IRouter.PairSwapSpecific[]
+            memory swapList = new IRouter.PairSwapSpecific[](1);
+        swapList[0] = IRouter.PairSwapSpecific({
+            pair: address(erc20NftPool),
+            nftIds: nftIds
+        });
+        execution.executeOrder = TestCallParameters({
+            target: address(ROUTER),
+            value: 0,
+            data: abi.encodeWithSelector(
+                IRouter.swapERC20ForSpecificNFTs.selector,
+                swapList,
+                erc20.amount,
+                context.fulfiller,
+                type(uint256).max
+            )
+        });
+    }
+
+    function getPayload_BuyOfferedERC20WithERC721(
+        TestOrderContext calldata context,
+        TestItem20 calldata erc20,
+        TestItem721 calldata nft
+    ) external override returns (TestOrderPayload memory execution) {
+        if (
+            !context.listOnChain ||
+            nft.token != erc721Address ||
+            erc20.token != erc20Address ||
+            erc20.amount != NFT_PRICE
+        ) _notImplemented();
+
+        // update market address so tests know where the ERC20 will be escrowed
+        currentMarket = address(erc20TokenPool);
+
+        // construct submitOrder payload
+        // offerer transfers ERC20 to erc20TokenPool
+        execution.submitOrder = TestCallParameters({
+            target: erc20.token,
+            value: 0,
+            data: abi.encodeWithSelector(
+                ERC20.transfer.selector,
+                address(erc20TokenPool),
+                erc20.amount
+            )
+        });
+
+        // construct executeOrder payload
+        // fulfiller calls router
+        uint256[] memory nftIds = new uint256[](1);
+        nftIds[0] = nft.identifier;
+        IRouter.PairSwapSpecific[]
+            memory swapList = new IRouter.PairSwapSpecific[](1);
+        swapList[0] = IRouter.PairSwapSpecific({
+            pair: address(erc20TokenPool),
+            nftIds: nftIds
+        });
+        execution.executeOrder = TestCallParameters({
+            target: address(ROUTER),
+            value: 0,
+            data: abi.encodeWithSelector(
+                IRouter.swapNFTsForToken.selector,
+                swapList,
+                0,
+                context.fulfiller,
+                type(uint256).max
+            )
+        });
+    }
 }

--- a/src/marketplaces/sudoswap/interfaces/IPair.sol
+++ b/src/marketplaces/sudoswap/interfaces/IPair.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.8.0;
+
+interface IPair {
+  
+    function swapNFTsForToken(
+        uint256[] calldata nftIds,
+        uint256 minExpectedTokenOutput,
+        address payable tokenRecipient,
+        bool isRouter,
+        address routerCaller
+    ) external returns (uint256 outputAmount);
+
+    function swapTokenForSpecificNFTs(
+        uint256[] calldata nftIds,
+        uint256 maxExpectedTokenInput,
+        address nftRecipient,
+        bool isRouter,
+        address routerCaller
+    ) external payable returns (uint256 inputAmount);
+}

--- a/src/marketplaces/sudoswap/interfaces/IPairFactory.sol
+++ b/src/marketplaces/sudoswap/interfaces/IPairFactory.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.8.0;
 
 import { IPair } from "./IPair.sol";
 
-interface IPairFactoryLike {
+interface IPairFactory {
     enum PoolType {
         TOKEN,
         NFT,

--- a/src/marketplaces/sudoswap/interfaces/IPairFactory.sol
+++ b/src/marketplaces/sudoswap/interfaces/IPairFactory.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.8.0;
+
+import { IPair } from "./IPair.sol";
+
+interface IPairFactoryLike {
+    enum PoolType {
+        TOKEN,
+        NFT,
+        TRADE
+    }
+
+    function createPairETH(
+        address _nft,
+        address _bondingCurve,
+        address payable _assetRecipient,
+        PoolType _poolType,
+        uint128 _delta,
+        uint96 _fee,
+        uint128 _spotPrice,
+        uint256[] calldata _initialNFTIDs
+    ) external payable returns (IPair pair);
+
+    struct CreateERC20PairParams {
+        address token;
+        address nft;
+        address bondingCurve;
+        address payable assetRecipient;
+        PoolType poolType;
+        uint128 delta;
+        uint96 fee;
+        uint128 spotPrice;
+        uint256[] initialNFTIDs;
+        uint256 initialTokenBalance;
+    }
+
+    function createPairERC20(CreateERC20PairParams calldata params)
+        external
+        returns (IPair pair);
+}

--- a/src/marketplaces/sudoswap/interfaces/IPairFactory.sol
+++ b/src/marketplaces/sudoswap/interfaces/IPairFactory.sol
@@ -41,4 +41,7 @@ interface IPairFactory {
 
     function changeProtocolFeeMultiplier(uint256 _protocolFeeMultiplier)
         external;
+
+    function setRouterAllowed(address _router, bool isAllowed)
+        external;
 }

--- a/src/marketplaces/sudoswap/interfaces/IRouter.sol
+++ b/src/marketplaces/sudoswap/interfaces/IRouter.sol
@@ -26,4 +26,16 @@ interface IRouter {
         address tokenRecipient,
         uint256 deadline
     ) external returns (uint256 outputAmount);
+
+    function depositNFTs(
+        address _nft,
+        uint256[] calldata ids,
+        address recipient
+    ) external;
+
+    function depositNFTs(
+        address _nft,
+        uint256[] calldata ids,
+        address[] calldata recipients
+    ) external;
 }

--- a/src/marketplaces/sudoswap/interfaces/IRouter.sol
+++ b/src/marketplaces/sudoswap/interfaces/IRouter.sol
@@ -25,5 +25,5 @@ interface IRouter {
         uint256 minOutput,
         address tokenRecipient,
         uint256 deadline
-    ) external returns (uint256 outputAmount)
+    ) external returns (uint256 outputAmount);
 }

--- a/src/marketplaces/sudoswap/interfaces/IRouter.sol
+++ b/src/marketplaces/sudoswap/interfaces/IRouter.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.8.0;
+
+interface IRouter {
+    struct PairSwapSpecific {
+        address pair;
+        uint256[] nftIds;
+    }
+
+    function swapETHForSpecificNFTs(
+        PairSwapSpecific[] calldata swapList,
+        address payable ethRecipient,
+        address nftRecipient,
+        uint256 deadline
+    ) external payable returns (uint256 remainingValue);
+
+    function swapERC20ForSpecificNFTs(
+        PairSwapSpecific[] calldata swapList,
+        uint256 inputAmount,
+        address nftRecipient,
+        uint256 deadline
+    ) external returns (uint256 remainingValue);
+
+    function swapNFTsForToken(
+        PairSwapSpecific[] calldata swapList,
+        uint256 minOutput,
+        address tokenRecipient,
+        uint256 deadline
+    ) external returns (uint256 outputAmount)
+}

--- a/src/marketplaces/wyvern/WyvernConfig.sol
+++ b/src/marketplaces/wyvern/WyvernConfig.sol
@@ -535,6 +535,7 @@ contract WyvernConfig is BaseMarketConfig, WyvernTypeHashes {
     function beforeAllPrepareMarketplaceCall(
         address seller,
         address buyer,
+        address[] calldata,
         address[] calldata
     ) external pure override returns (SetupCall[] memory) {
         SetupCall[] memory setupCalls = new SetupCall[](2);

--- a/test/GenericMarketplaceTest.t.sol
+++ b/test/GenericMarketplaceTest.t.sol
@@ -6,6 +6,7 @@ import { SeaportConfig } from "../src/marketplaces/seaport/SeaportConfig.sol";
 import { FoundationConfig } from "../src/marketplaces/foundation/FoundationConfig.sol";
 import { X2Y2Config } from "../src/marketplaces/X2Y2/X2Y2Config.sol";
 import { LooksRareConfig } from "../src/marketplaces/looksRare/LooksRareConfig.sol";
+import { SudoswapConfig } from "../src/marketplaces/sudoswap/SudoswapConfig.sol";
 import { BaseMarketConfig } from "../src/BaseMarketConfig.sol";
 
 import { SetupCall, TestOrderPayload, TestOrderContext, TestCallParameters, TestItem20, TestItem721, TestItem1155 } from "../src/Types.sol";
@@ -21,6 +22,7 @@ contract GenericMarketplaceTest is BaseOrderTest {
     BaseMarketConfig foundationConfig;
     BaseMarketConfig x2y2Config;
     BaseMarketConfig looksRareConfig;
+    BaseMarketConfig sudoswapConfig;
 
     constructor() {
         seaportConfig = BaseMarketConfig(new SeaportConfig());
@@ -28,6 +30,7 @@ contract GenericMarketplaceTest is BaseOrderTest {
         foundationConfig = BaseMarketConfig(new FoundationConfig());
         x2y2Config = BaseMarketConfig(new X2Y2Config());
         looksRareConfig = BaseMarketConfig(new LooksRareConfig());
+        sudoswapConfig = BaseMarketConfig(new SudoswapConfig());
     }
 
     function testSeaport() external {
@@ -48,6 +51,10 @@ contract GenericMarketplaceTest is BaseOrderTest {
 
     function testLooksRare() external {
         benchmarkMarket(looksRareConfig);
+    }
+
+    function testSudoswap() external {
+        benchmarkMarket(sudoswapConfig);
     }
 
     function benchmarkMarket(BaseMarketConfig config) public {
@@ -250,7 +257,11 @@ contract GenericMarketplaceTest is BaseOrderTest {
                 payload.submitOrder
             );
 
-            assertEq(test721_1.ownerOf(1), alice);
+            // Allow the market to escrow after listing
+            assert(
+                test721_1.ownerOf(1) == alice ||
+                    test721_1.ownerOf(1) == config.market()
+            );
             assertEq(token1.balanceOf(alice), 0);
             assertEq(token1.balanceOf(bob), 100);
 
@@ -395,7 +406,11 @@ contract GenericMarketplaceTest is BaseOrderTest {
             );
 
             assertEq(test721_1.ownerOf(1), bob);
-            assertEq(token1.balanceOf(alice), 100);
+            // Allow the market to escrow after listing
+            assert(
+                token1.balanceOf(alice) == 100 ||
+                    token1.balanceOf(config.market()) == 100
+            );
             assertEq(token1.balanceOf(bob), 0);
 
             _benchmarkCallWithParams(

--- a/test/GenericMarketplaceTest.t.sol
+++ b/test/GenericMarketplaceTest.t.sol
@@ -75,6 +75,7 @@ contract GenericMarketplaceTest is BaseOrderTest {
         benchmark_BuyTenOfferedERC721WithEther_ListOnChain(config);
         benchmark_BuyTenOfferedERC721WithEther(config);
         benchmark_BuyTenOfferedERC721WithEtherDistinctOrders(config);
+        benchmark_BuyTenOfferedERC721WithErc20DistinctOrders(config);
     }
 
     function beforeAllPrepareMarketplaceTest(BaseMarketConfig config) internal {
@@ -934,6 +935,51 @@ contract GenericMarketplaceTest is BaseOrderTest {
             for (uint256 i = 1; i <= 10; i++) {
                 assertEq(test721_1.ownerOf(i), bob);
             }
+        } catch {
+            _logNotSupported(config.name(), testLabel);
+        }
+    }
+
+    function benchmark_BuyTenOfferedERC721WithErc20DistinctOrders(
+        BaseMarketConfig config
+    ) internal prepareTest(config) {
+        string memory testLabel = "(ERC721x10 -> ERC20 Distinct Orders)";
+
+        token1.mint(bob, 1045);
+        TestOrderContext[] memory contexts = new TestOrderContext[](10);
+        TestItem721[] memory nfts = new TestItem721[](10);
+        uint256[] memory erc20Amounts = new uint256[](10);
+
+        for (uint256 i = 0; i < 10; i++) {
+            test721_1.mint(alice, i + 1);
+            nfts[i] = TestItem721(address(test721_1), i + 1);
+            contexts[i] = TestOrderContext(false, alice, bob);
+            erc20Amounts[i] = 100 + i;
+        }
+
+        try
+            config.getPayload_BuyOfferedManyERC721WithErc20DistinctOrders(
+                contexts,
+                address(token1),
+                nfts,
+                erc20Amounts
+            )
+        returns (TestOrderPayload memory payload) {
+            for (uint256 i = 1; i <= 10; i++) {
+                assertEq(test721_1.ownerOf(i), alice);
+            }
+
+            _benchmarkCallWithParams(
+                config.name(),
+                string(abi.encodePacked(testLabel, " Fulfill /w Sigs")),
+                bob,
+                payload.executeOrder
+            );
+
+            for (uint256 i = 1; i <= 10; i++) {
+                assertEq(test721_1.ownerOf(i), bob);
+            }
+            assertEq(token1.balanceOf(alice), 1045);
         } catch {
             _logNotSupported(config.name(), testLabel);
         }

--- a/test/GenericMarketplaceTest.t.sol
+++ b/test/GenericMarketplaceTest.t.sol
@@ -83,7 +83,8 @@ contract GenericMarketplaceTest is BaseOrderTest {
         SetupCall[] memory setupCalls = config.beforeAllPrepareMarketplaceCall(
             alice,
             bob,
-            erc20Addresses
+            erc20Addresses,
+            erc721Addresses
         );
         for (uint256 i = 0; i < setupCalls.length; i++) {
             hevm.startPrank(setupCalls[i].sender);

--- a/test/utils/BaseOrderTest.sol
+++ b/test/utils/BaseOrderTest.sol
@@ -39,6 +39,7 @@ contract BaseOrderTest is DSTestPlus {
     TestERC20[] erc20s;
     address[] erc20Addresses;
     TestERC721[] erc721s;
+    address[] erc721Addresses;
     TestERC1155[] erc1155s;
     address[] accounts;
     mapping(address => uint256) internal privateKeys;
@@ -75,6 +76,7 @@ contract BaseOrderTest is DSTestPlus {
         erc20s = [token1, token2, token3];
         erc20Addresses = [address(token1), address(token2), address(token3)];
         erc721s = [test721_1, test721_2, test721_3];
+        erc721Addresses = [address(test721_1), address(test721_2), address(test721_3)];
         erc1155s = [test1155_1, test1155_2, test1155_3];
         allTokens = [
             address(token1),


### PR DESCRIPTION
Added support for sudoswap markets.

We made a few high-level changes to the testing interface allow for compatibility with our contracts.
The main ones being:
- `beforeAllPrepareMarketplaceCall` has access to ERC721 addresses
- ownership calls for the List-On-Chain tests have been loosened to allow for other addresses to be owner (in our case, and for future cases where assets are escrowed)
- we added a new `benchmark_BuyTenOfferedERC721WithEtherDistinctOrders_ListOnChain` to support our on-chain equivalent of fulfilling multiple distinct orders in one tx  