### PR TITLE
Add list on chain for erc721x10 -> eth distinct orders test

### DIFF
--- a/src/Types.sol
+++ b/src/Types.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.7;
 
-type TestItemETH is uint256;
-
 struct TestItem721 {
     address token;
     uint256 identifier;

--- a/src/marketplaces/seaport/SeaportConfig.sol
+++ b/src/marketplaces/seaport/SeaportConfig.sol
@@ -862,6 +862,15 @@ contract SeaportConfig is BaseMarketConfig, ConsiderationTypeHashes {
                 ethAmounts
             );
 
+        // Validate all for simplicity for now, could make this combination of on-chain and not
+        if (contexts[0].listOnChain) {
+            execution.submitOrder = TestCallParameters(
+                address(seaport),
+                0,
+                abi.encodeWithSelector(ISeaport.validate.selector, orders)
+            );
+        }
+
         execution.executeOrder = TestCallParameters(
             address(seaport),
             sumEthAmount,

--- a/src/marketplaces/seaport/SeaportConfig.sol
+++ b/src/marketplaces/seaport/SeaportConfig.sol
@@ -183,6 +183,7 @@ contract SeaportConfig is BaseMarketConfig, ConsiderationTypeHashes {
         for (uint256 i = 0; i < nfts.length; i++) {
             // Build offer orders
             OfferItem[] memory offerItems = new OfferItem[](1);
+
             ConsiderationItem[]
                 memory considerationItems = new ConsiderationItem[](1);
             {
@@ -225,16 +226,20 @@ contract SeaportConfig is BaseMarketConfig, ConsiderationTypeHashes {
             }
             {
                 // Add fulfillment components for each NFT
+
                 FulfillmentComponent
                     memory nftConsiderationComponent = FulfillmentComponent(
                         nfts.length,
                         i
                     );
+
                 FulfillmentComponent
                     memory nftOfferComponent = FulfillmentComponent(i, 0);
+
                 FulfillmentComponent[]
                     memory nftOfferComponents = new FulfillmentComponent[](1);
                 nftOfferComponents[0] = nftOfferComponent;
+
                 FulfillmentComponent[]
                     memory nftConsiderationComponents = new FulfillmentComponent[](
                         1
@@ -259,11 +264,13 @@ contract SeaportConfig is BaseMarketConfig, ConsiderationTypeHashes {
                     nfts.length,
                     0
                 );
+
             FulfillmentComponent[]
                 memory paymentTokenOfferComponents = new FulfillmentComponent[](
                     1
                 );
             paymentTokenOfferComponents[0] = paymentTokenOfferComponent;
+
             FulfillmentComponent[]
                 memory paymentTokenConsiderationComponents = new FulfillmentComponent[](
                     nfts.length
@@ -959,14 +966,17 @@ contract SeaportConfig is BaseMarketConfig, ConsiderationTypeHashes {
                         i,
                         0
                     );
+
                 FulfillmentComponent
                     memory nftOfferComponent = FulfillmentComponent(
                         wrappedIndex,
                         0
                     );
+
                 FulfillmentComponent[]
                     memory nftOfferComponents = new FulfillmentComponent[](1);
                 nftOfferComponents[0] = nftOfferComponent;
+
                 FulfillmentComponent[]
                     memory nftConsiderationComponents = new FulfillmentComponent[](
                         1

--- a/src/marketplaces/sudoswap/SudoswapConfig.sol
+++ b/src/marketplaces/sudoswap/SudoswapConfig.sol
@@ -207,6 +207,7 @@ contract SudoswapConfig is BaseMarketConfig {
         // fulfiller calls router
         uint256[] memory nftIds = new uint256[](1);
         nftIds[0] = nft.identifier;
+
         IRouter.PairSwapSpecific[]
             memory swapList = new IRouter.PairSwapSpecific[](1);
         swapList[0] = IRouter.PairSwapSpecific({
@@ -257,6 +258,7 @@ contract SudoswapConfig is BaseMarketConfig {
         // fulfiller calls router
         uint256[] memory nftIds = new uint256[](1);
         nftIds[0] = nft.identifier;
+
         IRouter.PairSwapSpecific[]
             memory swapList = new IRouter.PairSwapSpecific[](1);
         swapList[0] = IRouter.PairSwapSpecific({
@@ -327,15 +329,14 @@ contract SudoswapConfig is BaseMarketConfig {
         TestItem721[] calldata nfts,
         uint256[] calldata ethAmounts
     ) external view override returns (TestOrderPayload memory execution) {
-
         if (!contexts[0].listOnChain) _notImplemented();
 
         address[] memory pools = new address[](nfts.length);
         uint256[] memory ids = new uint256[](nfts.length);
 
         for (uint256 i = 0; i < nfts.length; i++) {
-          pools[i] = address(ethNftPoolsForDistinct[i]);
-          ids[i] = nfts[i].identifier;
+            pools[i] = address(ethNftPoolsForDistinct[i]);
+            ids[i] = nfts[i].identifier;
         }
 
         execution.submitOrder = TestCallParameters({
@@ -351,21 +352,22 @@ contract SudoswapConfig is BaseMarketConfig {
 
         // construct executeOrder payload
         // fulfiller calls router
+
         IRouter.PairSwapSpecific[]
             memory swapList = new IRouter.PairSwapSpecific[](nfts.length);
 
         for (uint256 i = 0; i < nfts.length; i++) {
-          uint256[] memory singleId = new uint256[](1);
-          singleId[0] = nfts[i].identifier;
-          swapList[i] = IRouter.PairSwapSpecific({
-            pair: address(ethNftPoolsForDistinct[i]),
-            nftIds: singleId
-          });
+            uint256[] memory singleId = new uint256[](1);
+            singleId[0] = nfts[i].identifier;
+            swapList[i] = IRouter.PairSwapSpecific({
+                pair: address(ethNftPoolsForDistinct[i]),
+                nftIds: singleId
+            });
         }
 
         uint256 totalEthAmount = 0;
         for (uint256 i = 0; i < ethAmounts.length; i++) {
-          totalEthAmount += ethAmounts[i];
+            totalEthAmount += ethAmounts[i];
         }
 
         execution.executeOrder = TestCallParameters({

--- a/src/marketplaces/sudoswap/interfaces/IPair.sol
+++ b/src/marketplaces/sudoswap/interfaces/IPair.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.8.0;
 
 interface IPair {
-  
     function swapNFTsForToken(
         uint256[] calldata nftIds,
         uint256 minExpectedTokenOutput,

--- a/src/marketplaces/sudoswap/interfaces/IPairFactory.sol
+++ b/src/marketplaces/sudoswap/interfaces/IPairFactory.sol
@@ -42,6 +42,5 @@ interface IPairFactory {
     function changeProtocolFeeMultiplier(uint256 _protocolFeeMultiplier)
         external;
 
-    function setRouterAllowed(address _router, bool isAllowed)
-        external;
+    function setRouterAllowed(address _router, bool isAllowed) external;
 }

--- a/test/GenericMarketplaceTest.t.sol
+++ b/test/GenericMarketplaceTest.t.sol
@@ -81,7 +81,9 @@ contract GenericMarketplaceTest is BaseOrderTest {
         benchmark_BuyOfferedERC721WithEtherFeeTwoRecipients(config);
         benchmark_BuyTenOfferedERC721WithEther_ListOnChain(config);
         benchmark_BuyTenOfferedERC721WithEther(config);
-        benchmark_BuyTenOfferedERC721WithEtherDistinctOrders_ListOnChain(config);
+        benchmark_BuyTenOfferedERC721WithEtherDistinctOrders_ListOnChain(
+            config
+        );
         benchmark_BuyTenOfferedERC721WithEtherDistinctOrders(config);
         benchmark_BuyTenOfferedERC721WithErc20DistinctOrders(config);
         benchmark_MatchOrders_ABCA(config);
@@ -965,7 +967,8 @@ contract GenericMarketplaceTest is BaseOrderTest {
     function benchmark_BuyTenOfferedERC721WithEtherDistinctOrders_ListOnChain(
         BaseMarketConfig config
     ) internal prepareTest(config) {
-        string memory testLabel = "(ERC721x10 -> ETH Distinct Orders List-On-Chain)";
+        string
+            memory testLabel = "(ERC721x10 -> ETH Distinct Orders List-On-Chain)";
 
         TestOrderContext[] memory contexts = new TestOrderContext[](10);
         TestItem721[] memory nfts = new TestItem721[](10);
@@ -985,7 +988,6 @@ contract GenericMarketplaceTest is BaseOrderTest {
                 ethAmounts
             )
         returns (TestOrderPayload memory payload) {
-
             _benchmarkCallWithParams(
                 config.name(),
                 string(abi.encodePacked(testLabel, " List")),

--- a/test/utils/BaseOrderTest.sol
+++ b/test/utils/BaseOrderTest.sol
@@ -76,7 +76,11 @@ contract BaseOrderTest is DSTestPlus {
         erc20s = [token1, token2, token3];
         erc20Addresses = [address(token1), address(token2), address(token3)];
         erc721s = [test721_1, test721_2, test721_3];
-        erc721Addresses = [address(test721_1), address(test721_2), address(test721_3)];
+        erc721Addresses = [
+            address(test721_1),
+            address(test721_2),
+            address(test721_3)
+        ];
         erc1155s = [test1155_1, test1155_2, test1155_3];
         allTokens = [
             address(token1),


### PR DESCRIPTION
Also running linter on everything

Weird, locally I'm seeing:
```
~/opensea/marketplace-benchmarks kartik/seaport-erc721x10-eth-on-chain
❯   yarn lint:check

yarn run v1.22.19
$ prettier --check **.sol && prettier --check **.js
Checking formatting...
All matched files use Prettier code style!
Checking formatting...
All matched files use Prettier code style!
✨  Done in 1.76s.
```