### PR TITLE
Add ZeroExConfig

### DIFF
--- a/src/marketplaces/zeroEx/ZeroExConfig.sol
+++ b/src/marketplaces/zeroEx/ZeroExConfig.sol
@@ -1,0 +1,689 @@
+pragma solidity ^0.8.0;
+
+import "solmate/tokens/ERC20.sol";
+import "forge-std/Test.sol";
+
+import { BaseMarketConfig } from "../../BaseMarketConfig.sol";
+import { SetupCall, TestCallParameters, TestOrderContext, TestOrderPayload, TestItem721, TestItem1155, TestItem20 } from "../../Types.sol";
+import { IZeroEx } from "./interfaces/IZeroEx.sol";
+import "./lib/LibNFTOrder.sol";
+import "./lib/LibSignature.sol";
+
+contract ZeroExConfig is BaseMarketConfig, Test {
+
+    IZeroEx constant zeroEx = IZeroEx(0xDef1C0ded9bec7F1a1670819833240f027b25EfF);
+    address constant NATIVE_TOKEN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    // Note: in order to take advantage of a gas optimization, first create a "used" nonce
+    uint256 usedNonce = uint256(0x1010101000000000);
+    uint256 testNonce = uint256(0x1010101000000001);
+
+    function name() external pure override returns (string memory) {
+        return "ZeroEx";
+    }
+
+    function market() public pure override returns (address) {
+        return address(zeroEx);
+    }
+
+    function beforeAllPrepareMarketplace(address seller, address) external override {
+        buyerNftApprovalTarget = sellerNftApprovalTarget = buyerErc20ApprovalTarget = sellerErc20ApprovalTarget = address(
+            zeroEx
+        );
+
+        // Consume the usedNonce, allows for testNonce to become gas optimized
+        vm.prank(seller);
+        zeroEx.cancelERC721Order(usedNonce);
+    }
+
+    function getPayload_BuyOfferedERC721WithEther(
+        TestOrderContext calldata context,
+        TestItem721 memory nft,
+        uint256 ethAmount
+    ) external view override returns (TestOrderPayload memory execution) {
+
+        // Prepare the order
+        LibNFTOrder.ERC721Order memory order = LibNFTOrder.ERC721Order({
+            direction: LibNFTOrder.TradeDirection.SELL_NFT,
+            maker: context.offerer,
+            taker: context.fulfiller,
+            expiry: block.timestamp + 120,
+            nonce: testNonce,
+            erc20Token: NATIVE_TOKEN_ADDRESS, // 0x orders are able to be "bought" with the native token using this sentinel value
+            erc20TokenAmount: ethAmount,
+            fees: new LibNFTOrder.Fee[](0),
+            erc721Token: nft.token,
+            erc721TokenId: nft.identifier,
+            erc721TokenProperties: new LibNFTOrder.Property[](0)
+        });
+
+        // Sign the order
+        (uint8 v, bytes32 r, bytes32 s) = _sign(order.maker, zeroEx.getERC721OrderHash(order));
+        
+        // Prepare the signature
+        LibSignature.Signature memory sig = LibSignature.Signature({
+            signatureType: LibSignature.SignatureType.EIP712,
+            v: v,
+            r: r,
+            s: s
+        });
+
+        // Handle special case if "listing on chain" or in the 0x parlance the order is "presigned"
+        if (context.listOnChain) {
+            sig = LibSignature.Signature({
+                signatureType: LibSignature.SignatureType.PRESIGNED,
+                v: 0,
+                r: 0,
+                s: 0
+            });
+
+            execution.submitOrder = TestCallParameters(
+                address(zeroEx),
+                0,
+                abi.encodeWithSelector(IZeroEx.preSignERC721Order.selector, order)
+            );
+        }
+
+        // Execute the buy
+        execution.executeOrder = TestCallParameters(
+            address(zeroEx),
+            ethAmount,
+            abi.encodeWithSelector(
+                IZeroEx.buyERC721.selector,
+                order,
+                sig,
+                ""
+            )
+        );
+    }
+
+    function getPayload_BuyOfferedERC1155WithEther(
+        TestOrderContext calldata context,
+        TestItem1155 memory nft,
+        uint256 ethAmount
+    ) external view override returns (TestOrderPayload memory execution) {
+        // Prepare the order
+        LibNFTOrder.ERC1155Order memory order = LibNFTOrder.ERC1155Order({
+            direction: LibNFTOrder.TradeDirection.SELL_NFT,
+            maker: context.offerer,
+            taker: context.fulfiller,
+            expiry: block.timestamp + 120,
+            nonce: testNonce, // TODO - there exists a significant gas optimization that can be done with careful selection of the nonce
+            erc20Token: NATIVE_TOKEN_ADDRESS, // 0x orders are able to be "bought" with the native token using this sentinel value
+            erc20TokenAmount: ethAmount,
+            fees: new LibNFTOrder.Fee[](0),
+            erc1155Token: nft.token,
+            erc1155TokenId: nft.identifier,
+            erc1155TokenAmount: uint128(nft.amount),
+            erc1155TokenProperties: new LibNFTOrder.Property[](0)
+        });
+
+        // Sign the order
+        (uint8 v, bytes32 r, bytes32 s) = _sign(order.maker, zeroEx.getERC1155OrderHash(order));
+        
+        // Prepare the signature
+        LibSignature.Signature memory sig = LibSignature.Signature({
+            signatureType: LibSignature.SignatureType.EIP712,
+            v: v,
+            r: r,
+            s: s
+        });
+
+        // Handle special case if "listing on chain" or in the 0x parlance the order is "presigned"
+        if (context.listOnChain) {
+            sig = LibSignature.Signature({
+                signatureType: LibSignature.SignatureType.PRESIGNED,
+                v: 0,
+                r: 0,
+                s: 0
+            });
+
+            execution.submitOrder = TestCallParameters(
+                address(zeroEx),
+                0,
+                abi.encodeWithSelector(IZeroEx.preSignERC1155Order.selector, order)
+            );
+        }
+
+        // Execute the buy
+        execution.executeOrder = TestCallParameters(
+            address(zeroEx),
+            ethAmount,
+            abi.encodeWithSelector(
+                IZeroEx.buyERC1155.selector,
+                order,
+                sig,
+                uint128(nft.amount),
+                ""
+            )
+        );
+    }
+
+    function getPayload_BuyOfferedERC721WithERC20(
+        TestOrderContext calldata context,
+        TestItem721 memory nft,
+        TestItem20 memory erc20
+    ) external view override returns (TestOrderPayload memory execution) {
+
+        // Prepare the order
+        LibNFTOrder.ERC721Order memory order = LibNFTOrder.ERC721Order({
+            direction: LibNFTOrder.TradeDirection.SELL_NFT,
+            maker: context.offerer,
+            taker: context.fulfiller,
+            expiry: block.timestamp + 120,
+            nonce: testNonce,
+            erc20Token: erc20.token,
+            erc20TokenAmount: erc20.amount,
+            fees: new LibNFTOrder.Fee[](0),
+            erc721Token: nft.token,
+            erc721TokenId: nft.identifier,
+            erc721TokenProperties: new LibNFTOrder.Property[](0)
+        });
+
+        // Sign the order
+        (uint8 v, bytes32 r, bytes32 s) = _sign(order.maker, zeroEx.getERC721OrderHash(order));
+        
+        // Prepare the signature
+        LibSignature.Signature memory sig = LibSignature.Signature({
+            signatureType: LibSignature.SignatureType.EIP712,
+            v: v,
+            r: r,
+            s: s
+        });
+
+        // Handle special case if "listing on chain" or in the 0x parlance the order is "presigned"
+        if (context.listOnChain) {
+            sig = LibSignature.Signature({
+                signatureType: LibSignature.SignatureType.PRESIGNED,
+                v: 0,
+                r: 0,
+                s: 0
+            });
+
+            execution.submitOrder = TestCallParameters(
+                address(zeroEx),
+                0,
+                abi.encodeWithSelector(IZeroEx.preSignERC721Order.selector, order)
+            );
+        }
+
+        // Execute the buy
+        execution.executeOrder = TestCallParameters(
+            address(zeroEx),
+            0,
+            abi.encodeWithSelector(
+                IZeroEx.buyERC721.selector,
+                order,
+                sig,
+                ""
+            )
+        );
+    }
+
+    function getPayload_BuyOfferedERC1155WithERC20(
+        TestOrderContext calldata context,
+        TestItem1155 calldata nft,
+        TestItem20 memory erc20
+    ) external view override returns (TestOrderPayload memory execution) {
+        // Prepare the order
+        LibNFTOrder.ERC1155Order memory order = LibNFTOrder.ERC1155Order({
+            direction: LibNFTOrder.TradeDirection.SELL_NFT,
+            maker: context.offerer,
+            taker: context.fulfiller,
+            expiry: block.timestamp + 120,
+            nonce: testNonce,
+            erc20Token: erc20.token,
+            erc20TokenAmount: erc20.amount,
+            fees: new LibNFTOrder.Fee[](0),
+            erc1155Token: nft.token,
+            erc1155TokenId: nft.identifier,
+            erc1155TokenAmount: uint128(nft.amount),
+            erc1155TokenProperties: new LibNFTOrder.Property[](0)
+        });
+
+        // Sign the order
+        (uint8 v, bytes32 r, bytes32 s) = _sign(order.maker, zeroEx.getERC1155OrderHash(order));
+        
+        // Prepare the signature
+        LibSignature.Signature memory sig = LibSignature.Signature({
+            signatureType: LibSignature.SignatureType.EIP712,
+            v: v,
+            r: r,
+            s: s
+        });
+
+        // Handle special case if "listing on chain" or in the 0x parlance the order is "presigned"
+        if (context.listOnChain) {
+            sig = LibSignature.Signature({
+                signatureType: LibSignature.SignatureType.PRESIGNED,
+                v: 0,
+                r: 0,
+                s: 0
+            });
+
+            execution.submitOrder = TestCallParameters(
+                address(zeroEx),
+                0,
+                abi.encodeWithSelector(IZeroEx.preSignERC1155Order.selector, order)
+            );
+        }
+
+        // Execute the buy
+        execution.executeOrder = TestCallParameters(
+            address(zeroEx),
+            0,
+            abi.encodeWithSelector(
+                IZeroEx.buyERC1155.selector,
+                order,
+                sig,
+                uint128(nft.amount),
+                ""
+            )
+        );
+    }
+
+    function getPayload_BuyOfferedERC20WithERC721(
+        TestOrderContext calldata context,
+        TestItem20 memory erc20,
+        TestItem721 memory nft
+    ) external view override returns (TestOrderPayload memory execution) {
+        // Prepare the order
+        LibNFTOrder.ERC721Order memory order = LibNFTOrder.ERC721Order({
+            direction: LibNFTOrder.TradeDirection.BUY_NFT,
+            maker: context.offerer,
+            taker: context.fulfiller,
+            expiry: block.timestamp + 120,
+            nonce: testNonce,
+            erc20Token: erc20.token,
+            erc20TokenAmount: erc20.amount,
+            fees: new LibNFTOrder.Fee[](0),
+            erc721Token: nft.token,
+            erc721TokenId: nft.identifier,
+            erc721TokenProperties: new LibNFTOrder.Property[](0)
+        });
+
+        // Sign the order
+        (uint8 v, bytes32 r, bytes32 s) = _sign(order.maker, zeroEx.getERC721OrderHash(order));
+        
+        // Prepare the signature
+        LibSignature.Signature memory sig = LibSignature.Signature({
+            signatureType: LibSignature.SignatureType.EIP712,
+            v: v,
+            r: r,
+            s: s
+        });
+
+        // Handle special case if "listing on chain" or in the 0x parlance the order is "presigned"
+        if (context.listOnChain) {
+            sig = LibSignature.Signature({
+                signatureType: LibSignature.SignatureType.PRESIGNED,
+                v: 0,
+                r: 0,
+                s: 0
+            });
+
+            execution.submitOrder = TestCallParameters(
+                address(zeroEx),
+                0,
+                abi.encodeWithSelector(IZeroEx.preSignERC721Order.selector, order)
+            );
+        }
+
+        // Execute the sell
+        execution.executeOrder = TestCallParameters(
+            address(zeroEx),
+            0,
+            abi.encodeWithSelector(
+                IZeroEx.sellERC721.selector,
+                order,
+                sig,
+                nft.identifier,
+                false, // unwrap native token
+                "" // callback data
+            )
+        );
+    }
+
+    function getPayload_BuyOfferedERC20WithERC1155(
+        TestOrderContext calldata context,
+        TestItem20 memory erc20,
+        TestItem1155 calldata nft
+    ) external view override returns (TestOrderPayload memory execution) {
+        // Prepare the order
+        LibNFTOrder.ERC1155Order memory order = LibNFTOrder.ERC1155Order({
+            direction: LibNFTOrder.TradeDirection.BUY_NFT,
+            maker: context.offerer,
+            taker: context.fulfiller,
+            expiry: block.timestamp + 120,
+            nonce: testNonce,
+            erc20Token: erc20.token,
+            erc20TokenAmount: erc20.amount,
+            fees: new LibNFTOrder.Fee[](0),
+            erc1155Token: nft.token,
+            erc1155TokenId: nft.identifier,
+            erc1155TokenAmount: uint128(nft.amount),
+            erc1155TokenProperties: new LibNFTOrder.Property[](0)
+        });
+
+
+        // Sign the order
+        (uint8 v, bytes32 r, bytes32 s) = _sign(order.maker, zeroEx.getERC1155OrderHash(order));
+        
+        // Prepare the signature
+        LibSignature.Signature memory sig = LibSignature.Signature({
+            signatureType: LibSignature.SignatureType.EIP712,
+            v: v,
+            r: r,
+            s: s
+        });
+
+        // Handle special case if "listing on chain" or in the 0x parlance the order is "presigned"
+        if (context.listOnChain) {
+            sig = LibSignature.Signature({
+                signatureType: LibSignature.SignatureType.PRESIGNED,
+                v: 0,
+                r: 0,
+                s: 0
+            });
+
+            execution.submitOrder = TestCallParameters(
+                address(zeroEx),
+                0,
+                abi.encodeWithSelector(IZeroEx.preSignERC1155Order.selector, order)
+            );
+        }
+
+        // Execute the sell
+        execution.executeOrder = TestCallParameters(
+            address(zeroEx),
+            0,
+            abi.encodeWithSelector(
+                IZeroEx.sellERC1155.selector,
+                order,
+                sig,
+                nft.identifier,
+                uint128(nft.amount),
+                false, // unwrap native token
+                "" // callback data
+            )
+        );
+    }
+
+    function getPayload_BuyOfferedERC721WithEtherOneFeeRecipient(
+        TestOrderContext calldata context,
+        TestItem721 memory nft,
+        uint256 priceEthAmount,
+        address feeRecipient,
+        uint256 feeEthAmount
+    ) external view override returns (TestOrderPayload memory execution) {
+
+        // Prepare fees
+        LibNFTOrder.Fee[] memory fees = new LibNFTOrder.Fee[](1);
+        fees[0] = LibNFTOrder.Fee({
+            recipient: feeRecipient,
+            amount: feeEthAmount,
+            feeData: ""
+        });
+
+        // Prepare the order
+        LibNFTOrder.ERC721Order memory order = LibNFTOrder.ERC721Order({
+            direction: LibNFTOrder.TradeDirection.SELL_NFT,
+            maker: context.offerer,
+            taker: context.fulfiller,
+            expiry: block.timestamp + 120,
+            nonce: testNonce,
+            erc20Token: NATIVE_TOKEN_ADDRESS, // 0x orders are able to be "bought" with the native token using this sentinel value
+            erc20TokenAmount: priceEthAmount,
+            fees: fees,
+            erc721Token: nft.token,
+            erc721TokenId: nft.identifier,
+            erc721TokenProperties: new LibNFTOrder.Property[](0)
+        });
+
+        // Sign the order
+        (uint8 v, bytes32 r, bytes32 s) = _sign(order.maker, zeroEx.getERC721OrderHash(order));
+        
+        // Prepare the signature
+        LibSignature.Signature memory sig = LibSignature.Signature({
+            signatureType: LibSignature.SignatureType.EIP712,
+            v: v,
+            r: r,
+            s: s
+        });
+
+        // Handle special case if "listing on chain" or in the 0x parlance the order is "presigned"
+        if (context.listOnChain) {
+            sig = LibSignature.Signature({
+                signatureType: LibSignature.SignatureType.PRESIGNED,
+                v: 0,
+                r: 0,
+                s: 0
+            });
+
+            execution.submitOrder = TestCallParameters(
+                address(zeroEx),
+                0,
+                abi.encodeWithSelector(IZeroEx.preSignERC721Order.selector, order)
+            );
+        }
+
+        // Execute the buy
+        execution.executeOrder = TestCallParameters(
+            address(zeroEx),
+            priceEthAmount + feeEthAmount, // pay the maker and pay the fee
+            abi.encodeWithSelector(
+                IZeroEx.buyERC721.selector,
+                order,
+                sig,
+                ""
+            )
+        );
+    }
+
+    function getPayload_BuyOfferedERC721WithEtherTwoFeeRecipient(
+        TestOrderContext calldata context,
+        TestItem721 memory nft,
+        uint256 priceEthAmount,
+        address feeRecipient1,
+        uint256 feeEthAmount1,
+        address feeRecipient2,
+        uint256 feeEthAmount2
+    ) external view override returns (TestOrderPayload memory execution) {
+        // Prepare fees
+        LibNFTOrder.Fee[] memory fees = new LibNFTOrder.Fee[](2);
+        fees[0] = LibNFTOrder.Fee({
+            recipient: feeRecipient1,
+            amount: feeEthAmount1,
+            feeData: ""
+        });
+        fees[1] = LibNFTOrder.Fee({
+            recipient: feeRecipient2,
+            amount: feeEthAmount2,
+            feeData: ""
+        });
+
+        // Prepare the order
+        LibNFTOrder.ERC721Order memory order = LibNFTOrder.ERC721Order({
+            direction: LibNFTOrder.TradeDirection.SELL_NFT,
+            maker: context.offerer,
+            taker: context.fulfiller,
+            expiry: block.timestamp + 120,
+            nonce: testNonce,
+            erc20Token: NATIVE_TOKEN_ADDRESS, // 0x orders are able to be "bought" with the native token using this sentinel value
+            erc20TokenAmount: priceEthAmount,
+            fees: fees,
+            erc721Token: nft.token,
+            erc721TokenId: nft.identifier,
+            erc721TokenProperties: new LibNFTOrder.Property[](0)
+        });
+
+        // Sign the order
+        (uint8 v, bytes32 r, bytes32 s) = _sign(order.maker, zeroEx.getERC721OrderHash(order));
+        
+        // Prepare the signature
+        LibSignature.Signature memory sig = LibSignature.Signature({
+            signatureType: LibSignature.SignatureType.EIP712,
+            v: v,
+            r: r,
+            s: s
+        });
+
+        // Handle special case if "listing on chain" or in the 0x parlance the order is "presigned"
+        if (context.listOnChain) {
+            sig = LibSignature.Signature({
+                signatureType: LibSignature.SignatureType.PRESIGNED,
+                v: 0,
+                r: 0,
+                s: 0
+            });
+
+            execution.submitOrder = TestCallParameters(
+                address(zeroEx),
+                0,
+                abi.encodeWithSelector(IZeroEx.preSignERC721Order.selector, order)
+            );
+        }
+
+        // Execute the buy
+        execution.executeOrder = TestCallParameters(
+            address(zeroEx),
+            priceEthAmount + feeEthAmount1 + feeEthAmount2, // pay the maker and pay the fees
+            abi.encodeWithSelector(
+                IZeroEx.buyERC721.selector,
+                order,
+                sig,
+                ""
+            )
+        );
+    }
+
+    function getPayload_BuyOfferedManyERC721WithEtherDistinctOrders(
+        TestOrderContext[] calldata contexts,
+        TestItem721[] calldata nfts,
+        uint256[] calldata ethAmounts
+    ) external view override returns (TestOrderPayload memory execution) {
+        require(
+            contexts.length == nfts.length && nfts.length == ethAmounts.length,
+            "ZeroExConfig::getPayload_BuyOfferedManyERC721WithEtherDistinctOrders/ARRAY_LENGTH_MISMATCH"
+        );
+
+        LibNFTOrder.ERC721Order[] memory orders = new LibNFTOrder.ERC721Order[](contexts.length);
+        LibSignature.Signature[] memory sigs = new LibSignature.Signature[](contexts.length);
+        bytes[] memory callbacks = new bytes[](contexts.length);
+        uint256 sumEth = 0;
+
+        for (uint256 i = 0; i < contexts.length; i++) {
+            // Tally up the eth
+            sumEth += ethAmounts[i];
+
+            // Prepare the order
+            orders[i] = LibNFTOrder.ERC721Order({
+                direction: LibNFTOrder.TradeDirection.SELL_NFT,
+                maker: contexts[i].offerer,
+                taker: contexts[i].fulfiller,
+                expiry: block.timestamp + 120,
+                nonce: testNonce + i,
+                erc20Token: NATIVE_TOKEN_ADDRESS, // 0x orders are able to be "bought" with the native token using this sentinel value
+                erc20TokenAmount: ethAmounts[i],
+                fees: new LibNFTOrder.Fee[](0),
+                erc721Token: nfts[i].token,
+                erc721TokenId: nfts[i].identifier,
+                erc721TokenProperties: new LibNFTOrder.Property[](0)
+            });
+
+            // Sign the order
+            (uint8 v, bytes32 r, bytes32 s) = _sign(orders[i].maker, zeroEx.getERC721OrderHash(orders[i]));
+            
+            // Prepare the signature
+            sigs[i] = LibSignature.Signature({
+                signatureType: LibSignature.SignatureType.EIP712,
+                v: v,
+                r: r,
+                s: s
+            });
+
+        }
+
+        // Not sure how best to do this, not implementing for now
+        if (contexts[0].listOnChain) {
+            _notImplemented();
+
+        }
+
+        execution.executeOrder = TestCallParameters(
+            address(zeroEx),
+            sumEth,
+            abi.encodeWithSelector(
+                IZeroEx.batchBuyERC721s.selector,
+                orders,
+                sigs,
+                callbacks,
+                false
+            )
+        );
+    }
+
+    function getPayload_BuyOfferedManyERC721WithErc20DistinctOrders(
+        TestOrderContext[] calldata contexts,
+        address erc20Address,
+        TestItem721[] calldata nfts,
+        uint256[] calldata erc20Amounts
+    ) external view override returns (TestOrderPayload memory execution) {
+        require(
+            contexts.length == nfts.length &&
+                nfts.length == erc20Amounts.length,
+            "ZeroExConfig::getPayload_BuyOfferedManyERC721WithEtherDistinctOrders/ARRAY_LENGTH_MISMATCH"
+        );
+        LibNFTOrder.ERC721Order[] memory orders = new LibNFTOrder.ERC721Order[](contexts.length);
+        LibSignature.Signature[] memory sigs = new LibSignature.Signature[](contexts.length);
+        bytes[] memory callbacks = new bytes[](contexts.length);
+
+        for (uint256 i = 0; i < contexts.length; i++) {
+            // Prepare the order
+            orders[i] = LibNFTOrder.ERC721Order({
+                direction: LibNFTOrder.TradeDirection.SELL_NFT,
+                maker: contexts[i].offerer,
+                taker: contexts[i].fulfiller,
+                expiry: block.timestamp + 120,
+                nonce: testNonce + i,
+                erc20Token: erc20Address, 
+                erc20TokenAmount: erc20Amounts[i],
+                fees: new LibNFTOrder.Fee[](0),
+                erc721Token: nfts[i].token,
+                erc721TokenId: nfts[i].identifier,
+                erc721TokenProperties: new LibNFTOrder.Property[](0)
+            });
+
+            // Sign the order
+            (uint8 v, bytes32 r, bytes32 s) = _sign(orders[i].maker, zeroEx.getERC721OrderHash(orders[i]));
+            
+            // Prepare the signature
+            sigs[i] = LibSignature.Signature({
+                signatureType: LibSignature.SignatureType.EIP712,
+                v: v,
+                r: r,
+                s: s
+            });
+
+        }
+
+        // Not sure how best to do this, not implementing for now
+        if (contexts[0].listOnChain) {
+            _notImplemented();
+
+        }
+
+        execution.executeOrder = TestCallParameters(
+            address(zeroEx),
+            0,
+            abi.encodeWithSelector(
+                IZeroEx.batchBuyERC721s.selector,
+                orders,
+                sigs,
+                callbacks,
+                false
+            )
+        );
+    }
+
+}

--- a/src/marketplaces/zeroEx/ZeroExConfig.sol
+++ b/src/marketplaces/zeroEx/ZeroExConfig.sol
@@ -108,7 +108,7 @@ contract ZeroExConfig is BaseMarketConfig, Test {
             maker: context.offerer,
             taker: context.fulfiller,
             expiry: block.timestamp + 120,
-            nonce: testNonce, // TODO - there exists a significant gas optimization that can be done with careful selection of the nonce
+            nonce: testNonce,
             erc20Token: NATIVE_TOKEN_ADDRESS, // 0x orders are able to be "bought" with the native token using this sentinel value
             erc20TokenAmount: ethAmount,
             fees: new LibNFTOrder.Fee[](0),

--- a/src/marketplaces/zeroEx/ZeroExConfig.sol
+++ b/src/marketplaces/zeroEx/ZeroExConfig.sol
@@ -13,7 +13,6 @@ contract ZeroExConfig is BaseMarketConfig, Test {
 
     IZeroEx constant zeroEx = IZeroEx(0xDef1C0ded9bec7F1a1670819833240f027b25EfF);
     address constant NATIVE_TOKEN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     // Note: in order to take advantage of a gas optimization, first create a "used" nonce
     uint256 usedNonce = uint256(0x1010101000000000);
     uint256 testNonce = uint256(0x1010101000000001);

--- a/src/marketplaces/zeroEx/interfaces/IZeroEx.sol
+++ b/src/marketplaces/zeroEx/interfaces/IZeroEx.sol
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../lib/LibNFTOrder.sol";
+import "../lib/LibSignature.sol";
+
+interface IZeroEx {
+
+    /// IERC721OrdersFeature
+
+    /// @dev Sells an ERC721 asset to fill the given order.
+    /// @param buyOrder The ERC721 buy order.
+    /// @param signature The order signature from the maker.
+    /// @param erc721TokenId The ID of the ERC721 asset being
+    ///        sold. If the given order specifies properties,
+    ///        the asset must satisfy those properties. Otherwise,
+    ///        it must equal the tokenId in the order.
+    /// @param unwrapNativeToken If this parameter is true and the
+    ///        ERC20 token of the order is e.g. WETH, unwraps the
+    ///        token before transferring it to the taker.
+    /// @param callbackData If this parameter is non-zero, invokes
+    ///        `zeroExERC721OrderCallback` on `msg.sender` after
+    ///        the ERC20 tokens have been transferred to `msg.sender`
+    ///        but before transferring the ERC721 asset to the buyer.
+    function sellERC721(
+        LibNFTOrder.ERC721Order calldata buyOrder,
+        LibSignature.Signature calldata signature,
+        uint256 erc721TokenId,
+        bool unwrapNativeToken,
+        bytes calldata callbackData
+    )
+        external;
+
+    /// @dev Buys an ERC721 asset by filling the given order.
+    /// @param sellOrder The ERC721 sell order.
+    /// @param signature The order signature.
+    /// @param callbackData If this parameter is non-zero, invokes
+    ///        `zeroExERC721OrderCallback` on `msg.sender` after
+    ///        the ERC721 asset has been transferred to `msg.sender`
+    ///        but before transferring the ERC20 tokens to the seller.
+    ///        Native tokens acquired during the callback can be used
+    ///        to fill the order.
+    function buyERC721(
+        LibNFTOrder.ERC721Order calldata sellOrder,
+        LibSignature.Signature calldata signature,
+        bytes calldata callbackData
+    )
+        external
+        payable;
+
+    /// @dev Cancel a single ERC721 order by its nonce. The caller
+    ///      should be the maker of the order. Silently succeeds if
+    ///      an order with the same nonce has already been filled or
+    ///      cancelled.
+    /// @param orderNonce The order nonce.
+    function cancelERC721Order(uint256 orderNonce)
+        external;
+
+    /// @dev Cancel multiple ERC721 orders by their nonces. The caller
+    ///      should be the maker of the orders. Silently succeeds if
+    ///      an order with the same nonce has already been filled or
+    ///      cancelled.
+    /// @param orderNonces The order nonces.
+    function batchCancelERC721Orders(uint256[] calldata orderNonces)
+        external;
+
+    /// @dev Buys multiple ERC721 assets by filling the
+    ///      given orders.
+    /// @param sellOrders The ERC721 sell orders.
+    /// @param signatures The order signatures.
+    /// @param callbackData The data (if any) to pass to the taker
+    ///        callback for each order. Refer to the `callbackData`
+    ///        parameter to for `buyERC721`.
+    /// @param revertIfIncomplete If true, reverts if this
+    ///        function fails to fill any individual order.
+    /// @return successes An array of booleans corresponding to whether
+    ///         each order in `orders` was successfully filled.
+    function batchBuyERC721s(
+        LibNFTOrder.ERC721Order[] calldata sellOrders,
+        LibSignature.Signature[] calldata signatures,
+        bytes[] calldata callbackData,
+        bool revertIfIncomplete
+    )
+        external
+        payable
+        returns (bool[] memory successes);
+
+    /// @dev Matches a pair of complementary orders that have
+    ///      a non-negative spread. Each order is filled at
+    ///      their respective price, and the matcher receives
+    ///      a profit denominated in the ERC20 token.
+    /// @param sellOrder Order selling an ERC721 asset.
+    /// @param buyOrder Order buying an ERC721 asset.
+    /// @param sellOrderSignature Signature for the sell order.
+    /// @param buyOrderSignature Signature for the buy order.
+    /// @return profit The amount of profit earned by the caller
+    ///         of this function (denominated in the ERC20 token
+    ///         of the matched orders).
+    function matchERC721Orders(
+        LibNFTOrder.ERC721Order calldata sellOrder,
+        LibNFTOrder.ERC721Order calldata buyOrder,
+        LibSignature.Signature calldata sellOrderSignature,
+        LibSignature.Signature calldata buyOrderSignature
+    )
+        external
+        returns (uint256 profit);
+
+    /// @dev Matches pairs of complementary orders that have
+    ///      non-negative spreads. Each order is filled at
+    ///      their respective price, and the matcher receives
+    ///      a profit denominated in the ERC20 token.
+    /// @param sellOrders Orders selling ERC721 assets.
+    /// @param buyOrders Orders buying ERC721 assets.
+    /// @param sellOrderSignatures Signatures for the sell orders.
+    /// @param buyOrderSignatures Signatures for the buy orders.
+    /// @return profits The amount of profit earned by the caller
+    ///         of this function for each pair of matched orders
+    ///         (denominated in the ERC20 token of the order pair).
+    /// @return successes An array of booleans corresponding to
+    ///         whether each pair of orders was successfully matched.
+    function batchMatchERC721Orders(
+        LibNFTOrder.ERC721Order[] calldata sellOrders,
+        LibNFTOrder.ERC721Order[] calldata buyOrders,
+        LibSignature.Signature[] calldata sellOrderSignatures,
+        LibSignature.Signature[] calldata buyOrderSignatures
+    )
+        external
+        returns (uint256[] memory profits, bool[] memory successes);
+
+    /// @dev Callback for the ERC721 `safeTransferFrom` function.
+    ///      This callback can be used to sell an ERC721 asset if
+    ///      a valid ERC721 order, signature and `unwrapNativeToken`
+    ///      are encoded in `data`. This allows takers to sell their
+    ///      ERC721 asset without first calling `setApprovalForAll`.
+    /// @param operator The address which called `safeTransferFrom`.
+    /// @param from The address which previously owned the token.
+    /// @param tokenId The ID of the asset being transferred.
+    /// @param data Additional data with no specified format. If a
+    ///        valid ERC721 order, signature and `unwrapNativeToken`
+    ///        are encoded in `data`, this function will try to fill
+    ///        the order using the received asset.
+    /// @return success The selector of this function (0x150b7a02),
+    ///         indicating that the callback succeeded.
+    function onERC721Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    )
+        external
+        returns (bytes4 success);
+
+    /// @dev Approves an ERC721 order on-chain. After pre-signing
+    ///      the order, the `PRESIGNED` signature type will become
+    ///      valid for that order and signer.
+    /// @param order An ERC721 order.
+    function preSignERC721Order(LibNFTOrder.ERC721Order calldata order)
+        external;
+
+    /// @dev Checks whether the given signature is valid for the
+    ///      the given ERC721 order. Reverts if not.
+    /// @param order The ERC721 order.
+    /// @param signature The signature to validate.
+    function validateERC721OrderSignature(
+        LibNFTOrder.ERC721Order calldata order,
+        LibSignature.Signature calldata signature
+    )
+        external
+        view;
+
+    /// @dev If the given order is buying an ERC721 asset, checks
+    ///      whether or not the given token ID satisfies the required
+    ///      properties specified in the order. If the order does not
+    ///      specify any properties, this function instead checks
+    ///      whether the given token ID matches the ID in the order.
+    ///      Reverts if any checks fail, or if the order is selling
+    ///      an ERC721 asset.
+    /// @param order The ERC721 order.
+    /// @param erc721TokenId The ID of the ERC721 asset.
+    function validateERC721OrderProperties(
+        LibNFTOrder.ERC721Order calldata order,
+        uint256 erc721TokenId
+    )
+        external
+        view;
+
+    /// @dev Get the current status of an ERC721 order.
+    /// @param order The ERC721 order.
+    /// @return status The status of the order.
+    function getERC721OrderStatus(LibNFTOrder.ERC721Order calldata order)
+        external
+        view
+        returns (LibNFTOrder.OrderStatus status);
+
+    /// @dev Get the EIP-712 hash of an ERC721 order.
+    /// @param order The ERC721 order.
+    /// @return orderHash The order hash.
+    function getERC721OrderHash(LibNFTOrder.ERC721Order calldata order)
+        external
+        view
+        returns (bytes32 orderHash);
+
+    /// @dev Get the order status bit vector for the given
+    ///      maker address and nonce range.
+    /// @param maker The maker of the order.
+    /// @param nonceRange Order status bit vectors are indexed
+    ///        by maker address and the upper 248 bits of the
+    ///        order nonce. We define `nonceRange` to be these
+    ///        248 bits.
+    /// @return bitVector The order status bit vector for the
+    ///         given maker and nonce range.
+    function getERC721OrderStatusBitVector(address maker, uint248 nonceRange)
+        external
+        view
+        returns (uint256 bitVector);
+
+
+
+    /// IERC1155OrdersFeature
+
+    /// @dev Sells an ERC1155 asset to fill the given order.
+    /// @param buyOrder The ERC1155 buy order.
+    /// @param signature The order signature from the maker.
+    /// @param erc1155TokenId The ID of the ERC1155 asset being
+    ///        sold. If the given order specifies properties,
+    ///        the asset must satisfy those properties. Otherwise,
+    ///        it must equal the tokenId in the order.
+    /// @param erc1155SellAmount The amount of the ERC1155 asset
+    ///        to sell.
+    /// @param unwrapNativeToken If this parameter is true and the
+    ///        ERC20 token of the order is e.g. WETH, unwraps the
+    ///        token before transferring it to the taker.
+    /// @param callbackData If this parameter is non-zero, invokes
+    ///        `zeroExERC1155OrderCallback` on `msg.sender` after
+    ///        the ERC20 tokens have been transferred to `msg.sender`
+    ///        but before transferring the ERC1155 asset to the buyer.
+    function sellERC1155(
+        LibNFTOrder.ERC1155Order calldata buyOrder,
+        LibSignature.Signature calldata signature,
+        uint256 erc1155TokenId,
+        uint128 erc1155SellAmount,
+        bool unwrapNativeToken,
+        bytes calldata callbackData
+    )
+        external;
+
+    /// @dev Buys an ERC1155 asset by filling the given order.
+    /// @param sellOrder The ERC1155 sell order.
+    /// @param signature The order signature.
+    /// @param erc1155BuyAmount The amount of the ERC1155 asset
+    ///        to buy.
+    /// @param callbackData If this parameter is non-zero, invokes
+    ///        `zeroExERC1155OrderCallback` on `msg.sender` after
+    ///        the ERC1155 asset has been transferred to `msg.sender`
+    ///        but before transferring the ERC20 tokens to the seller.
+    ///        Native tokens acquired during the callback can be used
+    ///        to fill the order.
+    function buyERC1155(
+        LibNFTOrder.ERC1155Order calldata sellOrder,
+        LibSignature.Signature calldata signature,
+        uint128 erc1155BuyAmount,
+        bytes calldata callbackData
+    )
+        external
+        payable;
+
+    /// @dev Cancel a single ERC1155 order by its nonce. The caller
+    ///      should be the maker of the order. Silently succeeds if
+    ///      an order with the same nonce has already been filled or
+    ///      cancelled.
+    /// @param orderNonce The order nonce.
+    function cancelERC1155Order(uint256 orderNonce)
+        external;
+
+    /// @dev Cancel multiple ERC1155 orders by their nonces. The caller
+    ///      should be the maker of the orders. Silently succeeds if
+    ///      an order with the same nonce has already been filled or
+    ///      cancelled.
+    /// @param orderNonces The order nonces.
+    function batchCancelERC1155Orders(uint256[] calldata orderNonces)
+        external;
+
+    /// @dev Buys multiple ERC1155 assets by filling the
+    ///      given orders.
+    /// @param sellOrders The ERC1155 sell orders.
+    /// @param signatures The order signatures.
+    /// @param erc1155TokenAmounts The amounts of the ERC1155 assets
+    ///        to buy for each order.
+    /// @param callbackData The data (if any) to pass to the taker
+    ///        callback for each order. Refer to the `callbackData`
+    ///        parameter to for `buyERC1155`.
+    /// @param revertIfIncomplete If true, reverts if this
+    ///        function fails to fill any individual order.
+    /// @return successes An array of booleans corresponding to whether
+    ///         each order in `orders` was successfully filled.
+    function batchBuyERC1155s(
+        LibNFTOrder.ERC1155Order[] calldata sellOrders,
+        LibSignature.Signature[] calldata signatures,
+        uint128[] calldata erc1155TokenAmounts,
+        bytes[] calldata callbackData,
+        bool revertIfIncomplete
+    )
+        external
+        payable
+        returns (bool[] memory successes);
+
+    /// @dev Callback for the ERC1155 `safeTransferFrom` function.
+    ///      This callback can be used to sell an ERC1155 asset if
+    ///      a valid ERC1155 order, signature and `unwrapNativeToken`
+    ///      are encoded in `data`. This allows takers to sell their
+    ///      ERC1155 asset without first calling `setApprovalForAll`.
+    /// @param operator The address which called `safeTransferFrom`.
+    /// @param from The address which previously owned the token.
+    /// @param tokenId The ID of the asset being transferred.
+    /// @param value The amount being transferred.
+    /// @param data Additional data with no specified format. If a
+    ///        valid ERC1155 order, signature and `unwrapNativeToken`
+    ///        are encoded in `data`, this function will try to fill
+    ///        the order using the received asset.
+    /// @return success The selector of this function (0xf23a6e61),
+    ///         indicating that the callback succeeded.
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        uint256 value,
+        bytes calldata data
+    )
+        external
+        returns (bytes4 success);
+
+    /// @dev Approves an ERC1155 order on-chain. After pre-signing
+    ///      the order, the `PRESIGNED` signature type will become
+    ///      valid for that order and signer.
+    /// @param order An ERC1155 order.
+    function preSignERC1155Order(LibNFTOrder.ERC1155Order calldata order)
+        external;
+
+    /// @dev Checks whether the given signature is valid for the
+    ///      the given ERC1155 order. Reverts if not.
+    /// @param order The ERC1155 order.
+    /// @param signature The signature to validate.
+    function validateERC1155OrderSignature(
+        LibNFTOrder.ERC1155Order calldata order,
+        LibSignature.Signature calldata signature
+    )
+        external
+        view;
+
+    /// @dev If the given order is buying an ERC1155 asset, checks
+    ///      whether or not the given token ID satisfies the required
+    ///      properties specified in the order. If the order does not
+    ///      specify any properties, this function instead checks
+    ///      whether the given token ID matches the ID in the order.
+    ///      Reverts if any checks fail, or if the order is selling
+    ///      an ERC1155 asset.
+    /// @param order The ERC1155 order.
+    /// @param erc1155TokenId The ID of the ERC1155 asset.
+    function validateERC1155OrderProperties(
+        LibNFTOrder.ERC1155Order calldata order,
+        uint256 erc1155TokenId
+    )
+        external
+        view;
+
+    /// @dev Get the order info for an ERC1155 order.
+    /// @param order The ERC1155 order.
+    /// @return orderInfo Infor about the order.
+    function getERC1155OrderInfo(LibNFTOrder.ERC1155Order calldata order)
+        external
+        view
+        returns (LibNFTOrder.OrderInfo memory orderInfo);
+
+    /// @dev Get the EIP-712 hash of an ERC1155 order.
+    /// @param order The ERC1155 order.
+    /// @return orderHash The order hash.
+    function getERC1155OrderHash(LibNFTOrder.ERC1155Order calldata order)
+        external
+        view
+        returns (bytes32 orderHash);
+}

--- a/src/marketplaces/zeroEx/lib/LibNFTOrder.sol
+++ b/src/marketplaces/zeroEx/lib/LibNFTOrder.sol
@@ -1,0 +1,90 @@
+
+pragma solidity ^0.8.0;
+
+/// @dev A library for common NFT order operations.
+library LibNFTOrder {
+
+    enum OrderStatus {
+        INVALID,
+        FILLABLE,
+        UNFILLABLE,
+        EXPIRED
+    }
+
+    enum TradeDirection {
+        SELL_NFT,
+        BUY_NFT
+    }
+
+    struct Property {
+        address propertyValidator;
+        bytes propertyData;
+    }
+
+    struct Fee {
+        address recipient;
+        uint256 amount;
+        bytes feeData;
+    }
+
+    // "Base struct" for ERC721Order and ERC1155, used
+    // by the abstract contract `NFTOrders`.
+    struct NFTOrder {
+        TradeDirection direction;
+        address maker;
+        address taker;
+        uint256 expiry;
+        uint256 nonce;
+        address erc20Token;
+        uint256 erc20TokenAmount;
+        Fee[] fees;
+        address nft;
+        uint256 nftId;
+        Property[] nftProperties;
+    }
+
+    // All fields align with those of NFTOrder
+    struct ERC721Order {
+        TradeDirection direction;
+        address maker;
+        address taker;
+        uint256 expiry;
+        uint256 nonce;
+        address erc20Token;
+        uint256 erc20TokenAmount;
+        Fee[] fees;
+        address erc721Token;
+        uint256 erc721TokenId;
+        Property[] erc721TokenProperties;
+    }
+
+    // All fields except `erc1155TokenAmount` align
+    // with those of NFTOrder
+    struct ERC1155Order {
+        TradeDirection direction;
+        address maker;
+        address taker;
+        uint256 expiry;
+        uint256 nonce;
+        address erc20Token;
+        uint256 erc20TokenAmount;
+        Fee[] fees;
+        address erc1155Token;
+        uint256 erc1155TokenId;
+        Property[] erc1155TokenProperties;
+        // End of fields shared with NFTOrder
+        uint128 erc1155TokenAmount;
+    }
+
+    struct OrderInfo {
+        bytes32 orderHash;
+        OrderStatus status;
+        // `orderAmount` is 1 for all ERC721Orders, and
+        // `erc1155TokenAmount` for ERC1155Orders.
+        uint128 orderAmount;
+        // The remaining amount of the ERC721/ERC1155 asset
+        // that can be filled for the order.
+        uint128 remainingAmount;
+    }
+
+}

--- a/src/marketplaces/zeroEx/lib/LibSignature.sol
+++ b/src/marketplaces/zeroEx/lib/LibSignature.sol
@@ -1,0 +1,25 @@
+
+pragma solidity ^0.8.0;
+
+library LibSignature {
+
+    enum SignatureType {
+        ILLEGAL,
+        INVALID,
+        EIP712,
+        ETHSIGN,
+        PRESIGNED
+    }
+
+    struct Signature {
+        // How to validate the signature.
+        SignatureType signatureType;
+        // EC Signature data.
+        uint8 v;
+        // EC Signature data.
+        bytes32 r;
+        // EC Signature data.
+        bytes32 s;
+    }
+
+}

--- a/test/GenericMarketplaceTest.t.sol
+++ b/test/GenericMarketplaceTest.t.sol
@@ -7,6 +7,7 @@ import { FoundationConfig } from "../src/marketplaces/foundation/FoundationConfi
 import { X2Y2Config } from "../src/marketplaces/X2Y2/X2Y2Config.sol";
 import { LooksRareConfig } from "../src/marketplaces/looksRare/LooksRareConfig.sol";
 import { SudoswapConfig } from "../src/marketplaces/sudoswap/SudoswapConfig.sol";
+import { ZeroExConfig } from "../src/marketplaces/zeroEx/ZeroExConfig.sol";
 import { BaseMarketConfig } from "../src/BaseMarketConfig.sol";
 
 import { SetupCall, TestOrderPayload, TestOrderContext, TestCallParameters, TestItem20, TestItem721, TestItem1155 } from "../src/Types.sol";
@@ -23,6 +24,7 @@ contract GenericMarketplaceTest is BaseOrderTest {
     BaseMarketConfig x2y2Config;
     BaseMarketConfig looksRareConfig;
     BaseMarketConfig sudoswapConfig;
+    BaseMarketConfig zeroExConfig;
 
     constructor() {
         seaportConfig = BaseMarketConfig(new SeaportConfig());
@@ -31,6 +33,7 @@ contract GenericMarketplaceTest is BaseOrderTest {
         x2y2Config = BaseMarketConfig(new X2Y2Config());
         looksRareConfig = BaseMarketConfig(new LooksRareConfig());
         sudoswapConfig = BaseMarketConfig(new SudoswapConfig());
+        zeroExConfig = BaseMarketConfig(new ZeroExConfig());
     }
 
     function testSeaport() external {
@@ -55,6 +58,10 @@ contract GenericMarketplaceTest is BaseOrderTest {
 
     function testSudoswap() external {
         benchmarkMarket(sudoswapConfig);
+    }
+
+    function testZeroEx() external {
+        benchmarkMarket(zeroExConfig);
     }
 
     function benchmarkMarket(BaseMarketConfig config) public {


### PR DESCRIPTION
Adds ZeroExConfig, which provides support for 0x v4 NFT orders in the marketplace benchmarks. 

It should cover:
- ETH <-> ERC721
- ERC20 <-> ERC721
- ETH <-> ERC1155
- ERC20 <-> ERC1155
- 1 and 2 fee orders
- ERC721x10 via distinct orders

Not all features of 0x v4 are covered in the config, but hopefully, will be able to add coverage of features over time. Most of the significant features should be covered, however.